### PR TITLE
Fix config defaults and sanitization

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ class Config:
     LINE_CHANNEL_SECRET = os.getenv("LINE_CHANNEL_SECRET")
     # Database 配置
     DB_SERVER = os.getenv("DB_SERVER", "localhost")  # Default
-    DB_NAME = os.getenv("DB_NAME", "Project")  # Default
+    DB_NAME = os.getenv("DB_NAME", "conversations")  # Default
     DB_USER = os.getenv("DB_USER")  # For potential future use with non-trusted connections
     DB_PASSWORD = os.getenv("DB_PASSWORD")  # For potential future use
     # 驗證模式：嚴格 (strict) 或寬鬆 (loose)
@@ -77,16 +77,15 @@ class Config:
 
 
 # 應用程序啟動時嘗試驗證配置
-try:
-    # 這裡會根據 VALIDATION_MODE 環境變數決定驗證失敗行為
-    Config.validate()
-    logger.info("環境變數驗證成功")
-except ValueError as e:
-    is_testing = os.environ.get("TESTING", "False").lower() == "true"
-    if is_testing:
-        # 測試環境下只發出警告
-        logger.warning(f"測試環境：環境變數驗證失敗，但將繼續執行：{e}")
-    else:
+is_testing = os.environ.get("TESTING", "False").lower() == "true"
+if not is_testing:
+    try:
+        # 這裡會根據 VALIDATION_MODE 環境變數決定驗證失敗行為
+        Config.validate()
+        logger.info("環境變數驗證成功")
+    except ValueError as e:
         # 非測試環境且配置指定為寬鬆模式時，發出警告但不中斷
         logger.error(f"環境變數驗證失敗: {e}")
         # 注意：在寬鬆模式下，這裡沒有中斷程序，讓主程式決定如何處理
+else:
+    logger.debug("TESTING 模式啟用，略過環境變數驗證")

--- a/src/database.py
+++ b/src/database.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pyodbc
 from config import Config
 
@@ -521,4 +522,8 @@ class Database:
             }
 
 
-db = Database()
+# 在測試環境下避免連線到實際資料庫
+if os.environ.get("TESTING", "False").lower() != "true":
+    db = Database()
+else:
+    db = None

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 import time
-from html import escape
 from openai import OpenAI
 from database import db
 
@@ -15,18 +14,18 @@ def sanitize_input(text):
         return ""
     # 只跳脫尖括號，避免改變其他合法字元
     sanitized = text.replace("<", "&lt;").replace(">", "&gt;")
-    # 移除潛在惡意字元
-    sanitized = re.sub(r'[^\w\s.,;?!@#$%^&*()-=+\[\]{}:"\'/\\<>]', "", sanitized)
+    # 先允許保留反引號，稍後若無尖括號再移除
+    sanitized = re.sub(r'[^\w\s.,;?!@#$%^&*()-=+\[\]{}:"\'/\\<>`]', "", sanitized)
     # 若字串包含被轉義的尖括號，僅保留自第一個尖括號之後的內容
     if "&lt;" in sanitized or "&gt;" in sanitized:
-        first_lt = sanitized.find("&lt;") if "&lt;" in sanitized else -1
-        first_gt = sanitized.find("&gt;") if "&gt;" in sanitized else -1
-        first_pos_candidates = [p for p in (first_lt, first_gt) if p != -1]
-        first_pos = min(first_pos_candidates) if first_pos_candidates else -1
-        if first_pos != -1:
-            original_tail = text[text.find("<") if first_lt != -1 else text.find(">") :]
-            backticks = "".join(ch for ch in original_tail if ch == "`")
-            sanitized = sanitized[first_pos:] + backticks
+        first_pos = len(sanitized)
+        if "&lt;" in sanitized:
+            first_pos = min(first_pos, sanitized.find("&lt;"))
+        if "&gt;" in sanitized:
+            first_pos = min(first_pos, sanitized.find("&gt;"))
+        sanitized = sanitized[first_pos:]
+    else:
+        sanitized = sanitized.replace("`", "")
     return sanitized
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,15 @@
 import os
 import sys
 from unittest.mock import patch  # Standard library
-from config import Config      # Local application import (will be at top)
 
-# Ensure src is in path for imports if tests are run from root
-# This needs to be before importing 'config' for runtime, but after for flake8 E402
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+# Ensure src is in path for imports if tests are run from repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+# Tell the application code we are running in testing mode so configuration
+# validation does not abort the interpreter on import.
+os.environ["TESTING"] = "True"
+
+from config import Config  # Local application import
 
 
 def test_config_default_values():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,14 @@
 import os
 import sys
 import pytest  # Third-party import
-from main import sanitize_input  # Local application import (will be at top)
 
-# Ensure src is in path for imports if tests are run from root
-# This needs to be before importing 'main' for runtime, but after for flake8 E402
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+# Ensure src is in path for imports if tests are run from repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+# Prevent configuration validation from exiting during import
+os.environ["TESTING"] = "True"
+
+from main import sanitize_input  # Local application import
 
 
 @pytest.mark.parametrize("test_input,expected", [


### PR DESCRIPTION
備註

* 當設定 TESTING 標誌時，組態初始化現在會跳過環境變數驗證。這可防止測試因缺少環境變數而失敗。
* 在測試期間，也會跳過資料庫連線的建立，以避免連線錯誤。
* `sanitize_input` 已重構，以處理輸入包含類似 HTML 字元和反引號的邊界情況，符合測試中的預期。

摘要

* 預設資料庫名稱設為「conversations」，且在測試模式下會略過組態驗證。
* 資料庫模組在測試期間避免建立連線。
* 輸入清理僅對尖括號進行跳脫，必要時修剪前置文字，並適當保留反引號。
* 測試會插入 repository 的 src 路徑並標記環境為測試，確保匯入成功。
