### PR TITLE
feat(app.py, linebot_connect.py, main.py):提升安全性配置彈性

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@
 # 一般設定
 FLASK_DEBUG=False
 PORT=5000
+HOST=127.0.0.1
 SECRET_KEY=your_secret_key
+SECRET_KEY_FILE=data/secret_key.txt
 
 # OpenAI API
 OPENAI_API_KEY=your_openai_api_key

--- a/src/app.py
+++ b/src/app.py
@@ -94,8 +94,9 @@ def create_app(testing=False):
 # 提供一個便利函數來運行應用
 
 
-def run_app(host="0.0.0.0", port=None, debug=None, ssl_context=None):
+def run_app(host=None, port=None, debug=None, ssl_context=None):
     """運行 Flask 應用程序"""
+    host = host or os.environ.get("HOST", "127.0.0.1")
     port = port or int(os.environ.get("PORT", 5000))
     debug = debug or (os.environ.get("FLASK_DEBUG", "False").lower() == "true")
     app = create_app()

--- a/src/linebot_connect.py
+++ b/src/linebot_connect.py
@@ -60,8 +60,8 @@ if not channel_access_token or not channel_secret:
 # 判斷是否在測試環境 - 避免在測試期間啟用 Talisman 重定向
 is_testing = os.environ.get("TESTING", "False").lower() == "true"
 
-# 固定的密鑰文件路徑
-SECRET_KEY_FILE = "data/secret_key.txt"
+# 密鑰文件路徑可由環境變數覆蓋
+SECRET_KEY_FILE = os.getenv("SECRET_KEY_FILE", "data/secret_key.txt")
 
 
 def get_or_create_secret_key():

--- a/src/main.py
+++ b/src/main.py
@@ -248,7 +248,12 @@ if __name__ == "__main__":
     sys.modules["linebot_connect"] = linebot_connect
     spec.loader.exec_module(linebot_connect)
     port = int(os.environ.get("PORT", os.getenv("HTTPS_PORT", 443)))
-    linebot_connect.app.run(ssl_context=(
-        os.environ.get('SSL_CERT_PATH', 'certs/capstone-project.me-chain.pem'),  # fullchain
-        os.environ.get('SSL_KEY_PATH', 'certs/capstone-project.me-key.pem')),  # key
-        host="0.0.0.0", port=port, debug=False)
+    linebot_connect.app.run(
+        ssl_context=(
+            os.environ.get('SSL_CERT_PATH', 'certs/capstone-project.me-chain.pem'),
+            os.environ.get('SSL_KEY_PATH', 'certs/capstone-project.me-key.pem')
+        ),
+        host=os.environ.get("HOST", "127.0.0.1"),
+        port=port,
+        debug=False,
+    )


### PR DESCRIPTION
摘要

* Flask 應用程式的 run 函式現在會從環境變數讀取主機位址，預設為「127.0.0.1」，提升了可配置性與安全性。
* 主要進入點也使用可配置的主機位址來啟動應用程式伺服器。
* 密鑰檔案路徑現在可以透過 SECRET\_KEY\_FILE 環境變數進行設定，讓憑證管理更加靈活。
* README 檔已列出新的環境變數 HOST 和 SECRET\_KEY\_FILE，方便設定文件的說明。
